### PR TITLE
Add support for `calc()` within a calc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v2.3.0
+======
+
+#7: Add support for a ``calc()`` within a ``calc()``.
+
 v2.2.0
 ======
 

--- a/cssutils/css/csspagerule.py
+++ b/cssutils/css/csspagerule.py
@@ -203,7 +203,7 @@ class CSSPageRule(cssrule.CSSRuleRules):
             return expected
 
         def IDENT(expected, seq, token, tokenizer=None):
-            ""
+            """ """
             val = self._tokenvalue(token)
             if 'page' == expected:
                 if self._normalize(val) == 'auto':

--- a/cssutils/css/value.py
+++ b/cssutils/css/value.py
@@ -820,9 +820,9 @@ class CSSCalc(CSSFunction):
             ),
         )
 
-        _operant = lambda: Choice(
+        _operant = lambda: Choice(  # noqa:E731
             _DimensionProd(self), _CalcValueProd(self), _CSSVariableProd(self)
-        )  # noqa
+        )
 
         prods = Sequence(
             Prod(

--- a/cssutils/css/value.py
+++ b/cssutils/css/value.py
@@ -820,7 +820,7 @@ class CSSCalc(CSSFunction):
             ),
         )
 
-        _operant = lambda: Choice(_DimensionProd(self), _CSSVariableProd(self))  # noqa
+        _operant = lambda: Choice(_DimensionProd(self), _CalcValueProd(self), _CSSVariableProd(self))  # noqa
 
         prods = Sequence(
             Prod(

--- a/cssutils/css/value.py
+++ b/cssutils/css/value.py
@@ -820,7 +820,9 @@ class CSSCalc(CSSFunction):
             ),
         )
 
-        _operant = lambda: Choice(_DimensionProd(self), _CalcValueProd(self), _CSSVariableProd(self))  # noqa
+        _operant = lambda: Choice(
+            _DimensionProd(self), _CalcValueProd(self), _CSSVariableProd(self)
+        )  # noqa
 
         prods = Sequence(
             Prod(

--- a/cssutils/tests/test_value.py
+++ b/cssutils/tests/test_value.py
@@ -74,6 +74,8 @@ class PropertyValueTestCase(basetest.BaseTestCase):
             'calc(1  /  1px )': ('calc(1 / 1px)', 1, 'calc(1 / 1px)'),
             'calc( 1*1px )': ('calc(1 * 1px)', 1, 'calc(1 * 1px)'),
             'calc( 1  /  1px )': ('calc(1 / 1px)', 1, 'calc(1 / 1px)'),
+            'calc(calc(1px + 5px) * 4)': ('calc(calc(1px + 5px) * 4)', 1, 'calc(calc(1px + 5px) * 4)'),
+            'calc( calc(1px + 5px)*4 )': ('calc(calc(1px + 5px) * 4)', 1, 'calc(calc(1px + 5px) * 4)'),
             'calc(var(X))': (None, 1, None),
             'calc(2 * var(X))': (None, 1, None),
             'calc(2px + var(X))': (None, 1, None),

--- a/cssutils/tests/test_value.py
+++ b/cssutils/tests/test_value.py
@@ -74,8 +74,16 @@ class PropertyValueTestCase(basetest.BaseTestCase):
             'calc(1  /  1px )': ('calc(1 / 1px)', 1, 'calc(1 / 1px)'),
             'calc( 1*1px )': ('calc(1 * 1px)', 1, 'calc(1 * 1px)'),
             'calc( 1  /  1px )': ('calc(1 / 1px)', 1, 'calc(1 / 1px)'),
-            'calc(calc(1px + 5px) * 4)': ('calc(calc(1px + 5px) * 4)', 1, 'calc(calc(1px + 5px) * 4)'),
-            'calc( calc(1px + 5px)*4 )': ('calc(calc(1px + 5px) * 4)', 1, 'calc(calc(1px + 5px) * 4)'),
+            'calc(calc(1px + 5px) * 4)': (
+                'calc(calc(1px + 5px) * 4)',
+                1,
+                'calc(calc(1px + 5px) * 4)',
+            ),
+            'calc( calc(1px + 5px)*4 )': (
+                'calc(calc(1px + 5px) * 4)',
+                1,
+                'calc(calc(1px + 5px) * 4)',
+            ),
             'calc(var(X))': (None, 1, None),
             'calc(2 * var(X))': (None, 1, None),
             'calc(2px + var(X))': (None, 1, None),


### PR DESCRIPTION
Partially solves this issue: https://github.com/jaraco/cssutils/issues/5

This PR doesn't fully resolve the issue of nested calc functions, but it does allow for the use of a full `calc()` within a calc, [as is compliant](https://drafts.csswg.org/css-values-4/#example-364b1cfd). A statement like this still won't work: `calc((1 + 1px) * 2)`, but that CSS can now be updated to `calc(calc(1 + 1px) * 2)` to get the same rendered result. Some simple tests were added to verify this behaviour as well.