### PR TITLE
Force using importlib_resources in Python < 3.9

### DIFF
--- a/cssutils/tests/basetest.py
+++ b/cssutils/tests/basetest.py
@@ -6,9 +6,9 @@ import re
 import sys
 import unittest
 
-try:
+if sys.version_info >= (3, 9):
     from importlib import resources
-except ImportError:
+else:
     import importlib_resources as resources
 
 import cssutils


### PR DESCRIPTION
Force using the external importlib_resources package based on Python
version rather than the presence of the built-in importlib.resources.
The latter does not have the needed files() method in Python < 3.9,
and therefore results in test failures:

  E       AttributeError: module 'importlib.resources' has no attribute 'files'