### PR TITLE
Fix expected error message for python 3.10

### DIFF
--- a/cssutils/tests/basetest.py
+++ b/cssutils/tests/basetest.py
@@ -126,7 +126,7 @@ class BaseTestCase(unittest.TestCase):
             if not msg:
                 # No message provided: any message is fine.
                 return
-            elif excMsg == msg:
+            elif msg in excMsg:
                 # Message provided, and we got the right message: passes.
                 return
             else:


### PR DESCRIPTION
python 3.10 adds some words to it's errors, so catch if our expected are contained in the actual output.
It was tested to not regress on python 3.9 and 3.8

Fixes: https://github.com/jaraco/cssutils/issues/12