### PR TITLE
Support CSS variables with '--' prefix.

### DIFF
--- a/cssutils/cssproductions.py
+++ b/cssutils/cssproductions.py
@@ -25,7 +25,7 @@ MACROS = {
     'invalid1': r'\"([^\n\r\f\\"]|\\{nl}|{escape})*',
     'invalid2': r"\'([^\n\r\f\\']|\\{nl}|{escape})*",
     'comment': r'\/\*[^*]*\*+([^/][^*]*\*+)*\/',
-    'ident': r'[-]?{nmstart}{nmchar}*',
+    'ident': r'[-]{0,2}{nmstart}{nmchar}*',
     'name': r'{nmchar}+',
     # TODO???
     'num': r'[+-]?[0-9]*\.[0-9]+|[+-]?[0-9]+',  # r'[-]?\d+|[-]?\d*\.\d+',

--- a/cssutils/tests/test_tokenize2.py
+++ b/cssutils/tests/test_tokenize2.py
@@ -19,6 +19,7 @@ class TestTokenizer:
         ' a ': [('S', ' ', 1, 1), ('IDENT', 'a', 1, 2), ('S', ' ', 1, 3)],
         '_a': [('IDENT', '_a', 1, 1)],
         '-a': [('IDENT', '-a', 1, 1)],
+        '--a': [('IDENT', '--a', 1, 1)],
         'aA-_\200\377': [('IDENT', 'aA-_\200\377', 1, 1)],
         'a1': [('IDENT', 'a1', 1, 1)],
         # escapes must end with S or max 6 digits:

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ testing =
 	# upstream
 	pytest >= 6
 	pytest-checkdocs >= 2.4
+	flake8 <= 4.0.1
 	pytest-flake8
 	pytest-black >= 0.3.7; \
 		# workaround for jaraco/skeleton#22


### PR DESCRIPTION
As described in https://github.com/jaraco/cssutils/issues/14, the real CSS variables won't work. With one small fix, this can be resolved.

I also needed to lock `flake8` to 4.0.1 as flake8 >= 5 doesn't work with `pytest-flake8`