### PR TITLE
Add default variable for missing Property

### DIFF
--- a/cssutils/css/cssstyledeclaration.py
+++ b/cssutils/css/cssstyledeclaration.py
@@ -501,7 +501,7 @@ class CSSStyleDeclaration(CSS2Properties, cssutils.util.Base2):
         else:
             return None
 
-    def getPropertyValue(self, name, normalize=True):
+    def getPropertyValue(self, name, normalize=True, default=''):
         r"""
         :param name:
             of the CSS property, always lowercase (even if not normalized)
@@ -511,16 +511,18 @@ class CSSStyleDeclaration(CSS2Properties, cssutils.util.Base2):
 
             If ``False`` may return **NOT** the effective value but the
             effective for the unnormalized name.
+        :param default:
+            value to be returned if the property has not been set.
         :returns:
             the value of the effective property if it has been explicitly set
-            for this declaration block. Returns the empty string if the
+            for this declaration block. Returns `default` if the
             property has not been set.
         """
         p = self.getProperty(name, normalize)
         if p:
             return p.value
         else:
-            return ''
+            return default
 
     def getPropertyPriority(self, name, normalize=True):
         r"""

--- a/newsfragments/42.feature.rst
+++ b/newsfragments/42.feature.rst
@@ -1,0 +1,1 @@
+getPropertyValue now allows specifying a default value.


### PR DESCRIPTION
This change also makes it easier to discriminate between cases where the value is not set and where it is actually explicitly set to an empty string by using `default=None`.