### PR TITLE
Local definition of `unique_everseen` to avoid (relatively) large dependency

### DIFF
--- a/cssutils/util.py
+++ b/cssutils/util.py
@@ -8,8 +8,6 @@ import re
 import xml.dom
 from itertools import chain
 
-from more_itertools import unique_everseen
-
 import cssutils
 
 from . import codec, errorhandler, tokenize2
@@ -21,6 +19,28 @@ except ImportError:
     from ._fetch import _defaultFetcher
 
 log = errorhandler.ErrorHandler()
+
+
+def unique_everseen(iterable, key=None):
+    """
+    Yield unique elements, preserving order. Remember all elements ever seen.
+
+    This is the function available from the itertools recipe page:
+    https://docs.python.org/3/library/itertools.html#itertools-recipes
+    """
+    # unique_everseen('AAAABBBCCDAABBB') → A B C D
+    # unique_everseen('ABBcCAD', str.casefold) → A B c D
+    seen = set()
+    if key is None:
+        for element in filterfalse(seen.__contains__, iterable):
+            seen.add(element)
+            yield element
+    else:
+        for element in iterable:
+            k = key(element)
+            if k not in seen:
+                seen.add(k)
+                yield element
 
 
 class _BaseClass:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ classifiers = [
 	"Topic :: Text Processing :: Markup :: HTML",
 ]
 requires-python = ">=3.9"
-dependencies = [
-	"more_itertools",
-]
+dependencies = [ ]
 dynamic = ["version"]
 keywords = ["CSS", "Cascading Style Sheets", "CSSParser", "DOM Level 2 Stylesheets", "DOM Level 2 CSS"]
 


### PR DESCRIPTION
`unique_everseen` from `more_itertools` is used in this project. This library is 150KiB/5ksloc but only 16 of its lines are being used. Its inclusion as a dependency makes `cssutils` about 20% larger. This PR defines `unique_everseen` locally (though it's a copy of the stdlib itertool recipe, rather than exactly the one from `more_itertools`) and removes the dependency.