### PR TITLE
fix example rendering in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,35 +69,37 @@ Beware, cssutils is known to be thread unsafe.
 
 Example
 =======
-```python
-import cssutils
 
-css = '''/* a comment with umlaut &auml; */
-        @namespace html "http://www.w3.org/1999/xhtml";
-        @variables { BG: #fff }
-        html|a { color:red; background: var(BG) }'''
-sheet = cssutils.parseString(css)
+.. code-block:: python
 
-for rule in sheet:
-    if rule.type == rule.STYLE_RULE:
-        # find property
-        for property in rule.style:
-            if property.name == 'color':
-                property.value = 'green'
-                property.priority = 'IMPORTANT'
-                break
-        # or simply:
-        rule.style['margin'] = '01.0eM' # or: ('1em', 'important')
+    import cssutils
 
-sheet.encoding = 'ascii'
-sheet.namespaces['xhtml'] = 'http://www.w3.org/1999/xhtml'
-sheet.namespaces['atom'] = 'http://www.w3.org/2005/Atom'
-sheet.add('atom|title {color: #000000 !important}')
-sheet.add('@import "sheets/import.css";')
+    css = '''/* a comment with umlaut &auml; */
+            @namespace html "http://www.w3.org/1999/xhtml";
+            @variables { BG: #fff }
+            html|a { color:red; background: var(BG) }'''
+    sheet = cssutils.parseString(css)
 
-# cssutils.ser.prefs.resolveVariables == True since 0.9.7b2
-print sheet.cssText
-```
+    for rule in sheet:
+        if rule.type == rule.STYLE_RULE:
+            # find property
+            for property in rule.style:
+                if property.name == 'color':
+                    property.value = 'green'
+                    property.priority = 'IMPORTANT'
+                    break
+            # or simply:
+            rule.style['margin'] = '01.0eM' # or: ('1em', 'important')
+
+    sheet.encoding = 'ascii'
+    sheet.namespaces['xhtml'] = 'http://www.w3.org/1999/xhtml'
+    sheet.namespaces['atom'] = 'http://www.w3.org/2005/Atom'
+    sheet.add('atom|title {color: #000000 !important}')
+    sheet.add('@import "sheets/import.css";')
+
+    # cssutils.ser.prefs.resolveVariables == True since 0.9.7b2
+    print sheet.cssText
+
 results in::
 
 	@charset "ascii";


### PR DESCRIPTION
use code-block directive instead of triple-backtick fencing, since the file is rST not markdown