### PR TITLE
Fix code sample syntax (rST instead of Markdown)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,50 +69,54 @@ Beware, cssutils is known to be thread unsafe.
 
 Example
 =======
-```python
-import cssutils
 
-css = '''/* a comment with umlaut &auml; */
-        @namespace html "http://www.w3.org/1999/xhtml";
-        @variables { BG: #fff }
-        html|a { color:red; background: var(BG) }'''
-sheet = cssutils.parseString(css)
+.. code-block:: python
 
-for rule in sheet:
-    if rule.type == rule.STYLE_RULE:
-        # find property
-        for property in rule.style:
-            if property.name == 'color':
-                property.value = 'green'
-                property.priority = 'IMPORTANT'
-                break
-        # or simply:
-        rule.style['margin'] = '01.0eM' # or: ('1em', 'important')
+    import cssutils
+    
+    css = '''/* a comment with umlaut &auml; */
+            @namespace html "http://www.w3.org/1999/xhtml";
+            @variables { BG: #fff }
+            html|a { color:red; background: var(BG) }'''
+    sheet = cssutils.parseString(css)
+    
+    for rule in sheet:
+        if rule.type == rule.STYLE_RULE:
+            # find property
+            for property in rule.style:
+                if property.name == 'color':
+                    property.value = 'green'
+                    property.priority = 'IMPORTANT'
+                    break
+            # or simply:
+            rule.style['margin'] = '01.0eM' # or: ('1em', 'important')
+    
+    sheet.encoding = 'ascii'
+    sheet.namespaces['xhtml'] = 'http://www.w3.org/1999/xhtml'
+    sheet.namespaces['atom'] = 'http://www.w3.org/2005/Atom'
+    sheet.add('atom|title {color: #000000 !important}')
+    sheet.add('@import "sheets/import.css";')
+    
+    # cssutils.ser.prefs.resolveVariables == True since 0.9.7b2
+    print sheet.cssText
 
-sheet.encoding = 'ascii'
-sheet.namespaces['xhtml'] = 'http://www.w3.org/1999/xhtml'
-sheet.namespaces['atom'] = 'http://www.w3.org/2005/Atom'
-sheet.add('atom|title {color: #000000 !important}')
-sheet.add('@import "sheets/import.css";')
+.. highlight:: css
 
-# cssutils.ser.prefs.resolveVariables == True since 0.9.7b2
-print sheet.cssText
-```
-results in::
+Will result in::
 
-	@charset "ascii";
-	@import "sheets/import.css";
-	/* a comment with umlaut \E4  */
-	@namespace xhtml "http://www.w3.org/1999/xhtml";
-	@namespace atom "http://www.w3.org/2005/Atom";
-	xhtml|a {
-	    color: green !important;
-	    background: #fff;
-	    margin: 1em
-	    }
-	atom|title {
-	    color: #000 !important
-	    }
+    @charset "ascii";
+    @import "sheets/import.css";
+    /* a comment with umlaut \E4  */
+    @namespace xhtml "http://www.w3.org/1999/xhtml";
+    @namespace atom "http://www.w3.org/2005/Atom";
+    xhtml|a {
+        color: green !important;
+        background: #fff;
+        margin: 1em
+        }
+    atom|title {
+        color: #000 !important
+        }
 
 
 Kind Request


### PR DESCRIPTION
Backticks don't work in rST for code highlights, so the readme looks odd right now. Fixed including syntax change between Python and CSS