### PR TITLE
Link documentation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ Overview
 ========
 A Python package to parse and build CSS Cascading Style Sheets. DOM only, not any rendering facilities!
 
+You can find more documentation at `cssutils.readthedocs.io <https://cssutils.readthedocs.io>`_.
+
 Based upon and partly implementing the following specifications :
 
 `CSS 2.1rev1 <http://www.w3.org/TR/CSS2/>`__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ keywords = ["CSS", "Cascading Style Sheets", "CSSParser", "DOM Level 2 Styleshee
 
 [project.urls]
 Source = "https://github.com/jaraco/cssutils"
+Documentation = "https://cssutils.readthedocs.io"
+Issues = "https://github.com/jaraco/cssutils/issues"
+Changelog = "https://cssutils.readthedocs.io/en/latest/history.html"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
I know there is a link in form of the "Docs passing" image, but it's really easy to miss.

I also added a link to the docs, as well as issues and the changelog to the PyPI page (would show up with the next release) to make finding these places easier on people.