### PR TITLE
Specify packages using include rather than exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,14 +85,10 @@ csscombine = "cssutils.scripts.csscombine:main"
 cssparse = "cssutils.scripts.cssparse:main"
 
 [tool.setuptools.packages.find]
-exclude = [
-	# duplicate exclusions for pypa/setuptools#2688
-	"docs",
-	"docs.*",
-	"examples*",
-	"sheets",
-	"sheets.*",
-	"tools*",
+include = [
+	"cssutils",
+	"cssutils.*",
+	"encutils",
 ]
 namespaces = true
 


### PR DESCRIPTION
This avoids possible duplication if a wheel is built more than once from the same directory.

I ran into this when upgrading Debian's packaging of cssutils; we're currently in a transitional period where we're building for both Python 3.12 and 3.13, and this resulted in the second of the two wheels having a stray `build` directory.  Using `include` rather than `exclude` avoids this, and seems to be simpler anyway.